### PR TITLE
Swap 구조체에 amountOfAssets, premiumRate 추가 등

### DIFF
--- a/contract/contracts/Swaps/Swaps.sol
+++ b/contract/contracts/Swaps/Swaps.sol
@@ -102,6 +102,7 @@ contract Swaps is PriceConsumer {
     newSwap.premiumRate = _premiumRate;
     newSwap.premiumInterval = _premiumInterval;
     newSwap.totalPremiumRounds = _totalPremiumRounds;
+    newSwap.status = Status.pending;
 
     newSwap.seller.deposit = _sellerDeposit;
 

--- a/contract/contracts/Swaps/Swaps.sol
+++ b/contract/contracts/Swaps/Swaps.sol
@@ -36,17 +36,50 @@ contract Swaps is PriceConsumer {
     Buyer buyer;
     Seller seller;
     uint256 initAssetPrice;
+    uint256 amountOfAssets;
     uint256 claimPrice;
     uint256 liquidationPrice;
     uint256 premium;
+    uint256 premiumRate;
     uint256 premiumInterval;
     uint256 totalPremiumRounds;
     Status status;
   }
 
+  modifier isBuyer(uint256 swapId) {
+    require(
+      msg.sender == _swaps[swapId].buyer.addr,
+      'Only buyer of the CDS can call'
+    );
+    _;
+  }
+
+  modifier isPending(uint256 swapId) {
+    require(
+      _swaps[swapId].status == Status.pending,
+      'The status of the CDS should be pending'
+    );
+    _;
+  }
+
+  modifier isActive(uint256 swapId) {
+    require(
+      _swaps[swapId].status == Status.active,
+      'The status of the CDS should be pending'
+    );
+    _;
+  }
+
+  uint256 private _premiumRate;
+
+  constructor() {
+    _premiumRate = 2;
+  }
+
   function _createSwap(
     address _addr,
     uint256 _initAssetPrice,
+    uint256 _amountOfAssets,
     uint256 _claimPrice,
     uint256 _liquidationPrice,
     uint256 _sellerDeposit,
@@ -62,9 +95,11 @@ contract Swaps is PriceConsumer {
     newSwap.buyer.deposit = _premium.mul(3);
 
     newSwap.initAssetPrice = _initAssetPrice;
+    newSwap.amountOfAssets = _amountOfAssets;
     newSwap.claimPrice = _claimPrice;
     newSwap.liquidationPrice = _liquidationPrice;
     newSwap.premium = _premium;
+    newSwap.premiumRate = _premiumRate;
     newSwap.premiumInterval = _premiumInterval;
     newSwap.totalPremiumRounds = _totalPremiumRounds;
 

--- a/contract/contracts/Swaps/Swaps.sol
+++ b/contract/contracts/Swaps/Swaps.sol
@@ -11,9 +11,9 @@ contract Swaps is PriceConsumer {
   Counters.Counter internal _swapId;
 
   enum Status {
+    inactive,
     pending,
     active,
-    inactive,
     claimed
   }
 
@@ -114,7 +114,6 @@ contract Swaps is PriceConsumer {
     uint256 _acceptedSwapId
   ) internal returns (uint256) {
     Swap storage aSwap = _swaps[_acceptedSwapId];
-    require(aSwap.status == Status.pending, 'The CDS is not pending state');
 
     aSwap.seller.addr = _addr;
     aSwap.initAssetPrice = _initAssetPrice;

--- a/contract/contracts/libs/LibClaim.sol
+++ b/contract/contracts/libs/LibClaim.sol
@@ -6,22 +6,19 @@ import '@openzeppelin/contracts/utils/math/SafeMath.sol';
 library LibClaim {
   using SafeMath for uint256;
 
-  uint256 internal constant PERCENTAGE_BASE = 100;
-  uint256 internal constant PREMIUM_RATE = 2;
-  uint256 internal constant BUYER_DEPOSIT_RATE = 3;
-
   function calcClaimReward(
     uint256 _deposit,
     uint256 _liquidation,
     uint256 _initial,
+    uint256 _amountOfAssets,
     uint256 _current
   ) internal pure returns (uint256) {
     uint256 claimReward;
     if (_liquidation >= _current) {
       claimReward = _deposit;
     } else {
-      uint256 numOfAsset = _deposit.div(_initial.sub(_liquidation));
-      claimReward = numOfAsset.mul(_initial.sub(_current));
+      // uint256 numOfAsset = _deposit.div(_initial.sub(_liquidation));
+      claimReward = _amountOfAssets.mul(_initial.sub(_current));
     }
     return claimReward;
   }

--- a/contract/test/CDS.test.js
+++ b/contract/test/CDS.test.js
@@ -11,6 +11,7 @@ contract('CDS', (accounts) => {
   let priceOracle;
   let cds;
   const defaultInitAssetPrice = 100;
+  const defaultAmountOfAssets = 10;
   const defaultClaimPrice = 80;
   const defaultLiquidationPrice = 60;
   const defaultSellerDeposit = 60;
@@ -52,6 +53,7 @@ contract('CDS', (accounts) => {
         cds.createSwap(
           accounts[2],
           20000,
+          10,
           15000,
           10000,
           100000,
@@ -65,6 +67,7 @@ contract('CDS', (accounts) => {
         cds.createSwap(
           accounts[2],
           20000,
+          10,
           15000,
           10000,
           100000,
@@ -78,6 +81,7 @@ contract('CDS', (accounts) => {
         cds.createSwap(
           accounts[2],
           defaultInitAssetPrice,
+          defaultAmountOfAssets,
           defaultClaimPrice,
           defaultLiquidationPrice,
           defaultSellerDeposit,
@@ -94,6 +98,7 @@ contract('CDS', (accounts) => {
         cds.createSwap(
           accounts[2],
           defaultInitAssetPrice,
+          defaultAmountOfAssets,
           defaultClaimPrice,
           defaultLiquidationPrice,
           defaultSellerDeposit,
@@ -109,6 +114,7 @@ contract('CDS', (accounts) => {
         buyer,
         seller,
         initAssetPrice,
+        amountOfAssets,
         claimPrice,
         liquidationPrice,
         premium,
@@ -117,6 +123,7 @@ contract('CDS', (accounts) => {
       } = currentSwap;
 
       await assert.strictEqual(defaultInitAssetPrice, +initAssetPrice);
+      await assert.strictEqual(defaultAmountOfAssets, +amountOfAssets);
       await assert.strictEqual(defaultClaimPrice, +claimPrice);
       await assert.strictEqual(defaultLiquidationPrice, +liquidationPrice);
       await assert.strictEqual(defaultPremium, +premium);
@@ -135,6 +142,7 @@ contract('CDS', (accounts) => {
         cds.createSwap(
           accounts[0],
           defaultInitAssetPrice,
+          defaultAmountOfAssets,
           defaultClaimPrice,
           defaultLiquidationPrice,
           defaultSellerDeposit,
@@ -151,6 +159,7 @@ contract('CDS', (accounts) => {
       const receipt = await cds.createSwap(
         accounts[2],
         defaultInitAssetPrice,
+        defaultAmountOfAssets,
         defaultClaimPrice,
         defaultLiquidationPrice,
         defaultSellerDeposit,
@@ -186,6 +195,7 @@ contract('CDS', (accounts) => {
       await cds.createSwap(
         accounts[2],
         defaultInitAssetPrice,
+        defaultAmountOfAssets,
         defaultClaimPrice,
         defaultLiquidationPrice,
         defaultSellerDeposit,
@@ -208,6 +218,7 @@ contract('CDS', (accounts) => {
         buyer,
         seller,
         initAssetPrice,
+        amountOfAssets,
         claimPrice,
         liquidationPrice,
         premium,
@@ -216,6 +227,7 @@ contract('CDS', (accounts) => {
       } = currentSwap;
 
       await assert.strictEqual(defaultInitAssetPrice, +initAssetPrice);
+      await assert.strictEqual(defaultAmountOfAssets, +amountOfAssets);
       await assert.strictEqual(defaultClaimPrice, +claimPrice);
       await assert.strictEqual(defaultLiquidationPrice, +liquidationPrice);
       await assert.strictEqual(defaultPremium, +premium);
@@ -234,6 +246,7 @@ contract('CDS', (accounts) => {
       await cds.createSwap(
         accounts[2],
         defaultInitAssetPrice,
+        defaultAmountOfAssets,
         defaultClaimPrice,
         defaultLiquidationPrice,
         defaultSellerDeposit,
@@ -258,6 +271,7 @@ contract('CDS', (accounts) => {
       await cds.createSwap(
         accounts[2],
         defaultInitAssetPrice,
+        defaultAmountOfAssets,
         defaultClaimPrice,
         defaultLiquidationPrice,
         defaultSellerDeposit,
@@ -286,6 +300,7 @@ contract('CDS', (accounts) => {
         buyer,
         seller,
         initAssetPrice,
+        amountOfAssets,
         claimPrice,
         liquidationPrice,
         premium,
@@ -295,6 +310,7 @@ contract('CDS', (accounts) => {
       } = currentSwap;
 
       await assert.strictEqual(defaultInitAssetPrice, +initAssetPrice);
+      await assert.strictEqual(defaultAmountOfAssets, +amountOfAssets);
       await assert.strictEqual(defaultClaimPrice, +claimPrice);
       await assert.strictEqual(defaultLiquidationPrice, +liquidationPrice);
       await assert.strictEqual(defaultPremium, +premium);


### PR DESCRIPTION
Swap 구조체에 amountOfAssets, premiumRate 추가
cancleSwap, acceptSwap, claimSwap에 Status에 따른 modifier 추가
구조체 추가 data에 따른 test file 수정
